### PR TITLE
fix: Celeste primary activating when in passive slot

### DIFF
--- a/Assets/Prefabs/Copilots/Celeste.prefab
+++ b/Assets/Prefabs/Copilots/Celeste.prefab
@@ -90,7 +90,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5530163736713283340}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ab4acb2ff64d6494993b88bf0fc3ba08, type: 3}
   m_Name: 
@@ -108,7 +108,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5530163736713283340}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dee0f88094346694d8916d2bce00fde6, type: 3}
   m_Name: 

--- a/Assets/Prefabs/Copilots/MushroomFriend/Mushii.prefab
+++ b/Assets/Prefabs/Copilots/MushroomFriend/Mushii.prefab
@@ -97,7 +97,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   typeOfMechanic: 0
   abilityName: Regrowth
-  description: Spawn an orb that heals you
+  description: Spawn an orb that heals you slightly. Health must be 15% or below.
   icon: {fileID: 0}
   HealingBubblePrefab: {fileID: 7820509114651452771, guid: 0c4c09eb4c790a44ebc4ef3a0875c533,
     type: 3}

--- a/Assets/Scripts/CopilotMechanics/MushroomFriendActive.cs
+++ b/Assets/Scripts/CopilotMechanics/MushroomFriendActive.cs
@@ -9,7 +9,7 @@ public class MushroomFriendActive : CopilotActiveMechanic
     private GameObject healingBubble;   //Spawned bubble
     public int heal; //amount to heal player
     public float healTime; //time to restore health
-    public float minHealthPercentage = 0.25f;   //Percernt of max health needed to activate bubble
+    public float minHealthPercentage = 0.15f;   //Percernt of max health needed to activate bubble
     public bool healPlayer; //check that Player is allowed to heal
 
 

--- a/Assets/Scripts/Copilots/HealingBubble.cs
+++ b/Assets/Scripts/Copilots/HealingBubble.cs
@@ -19,6 +19,9 @@ public class HealingBubble : MonoBehaviour
     private bool healPlayer;
     private float healTime;
 
+    [SerializeField]
+    private int healAmount = 10;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -52,7 +55,7 @@ public class HealingBubble : MonoBehaviour
         //stop spore particle system and reset healing bubble
         if (sporeTimer < 0)
         {
-            PlayerInfo.singleton.health = PlayerInfo.singleton.maxHealth;
+            PlayerInfo.singleton.Heal(healAmount);
             spreParticles.Stop(true, ParticleSystemStopBehavior.StopEmitting);
             healPlayer = false;
             sporeTimer = 0;


### PR DESCRIPTION
- also nerf Mushii heal since it was just a better Celeste